### PR TITLE
Fix buggy build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ buck:
 	ocamlopt.opt -c -o mybuild/util_S.cmx -I util -I injector  util/util_S.ml
 	ocamlopt.opt -c -o mybuild/util.cmx -I util -I injector -I mybuild -w -58 util/util.ml
 	ocamlopt.opt -a -o mybuild/libutil.cmxa mybuild/default.cmx mybuild/test.cmx mybuild/util_S.cmx mybuild/util.cmx
-	ocamlopt.opt -c -o mybuild/injector.cmx -I injector/default -I injector injector/default/injector.ml
+	ocamlopt.opt -c -o mybuild/injector.cmx -intf-suffix .ml -I mybuild -I injector/default -I injector injector/default/injector.ml
 	ocamlopt.opt -a -o mybuild/libinjector.cmxa mybuild/injector.cmx 
 	ocamlopt.opt -c -o mybuild/main.cmx -I mybuild main.ml
 	ocamlopt.opt -o mybuild/main.opt mybuild/libinjector.cmxa mybuild/libutil.cmxa mybuild/main.cmx


### PR DESCRIPTION
The issue with the previous build was that producing the .cmx for injector also produced another .cmi. This .cmi ended up being different than the one produced by compiling the .mli.

As for why it was broken in 4.06 but not in 4.05, I don't a straight answer, but when OCaml thinks the .mli for the source is missing, it will infer one and use it to compile a .cmi. Perhaps the inferred mli somehow subtly changed and made it different than the written mli.

In any case, in dune we avoid all of these issues by making sure ocamlopt never produces .cmi files. One can do this with the -intf-suffix option. 